### PR TITLE
renegade-sdk: Add initial SDK implementation

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,63 @@
+# dependencies
+node_modules/
+.pnp
+.pnp.js
+
+# testing
+coverage
+
+# production
+dist/
+
+# misc
+.DS_Store
+*.pem
+
+# debug
+npm-debug.log*
+yarn-debug.log*
+yarn-error.log*
+
+# environment variables
+.env*
+
+# turbo
+.turbo
+
+# Vercel
+.vercel
+
+# Finder (MacOS) folder config
+.DS_Store
+
+# output
+out
+dist
+*.tgz
+
+# code coverage
+coverage
+*.lcov
+
+# logs
+logs
+_.log
+report.[0-9]_.[0-9]_.[0-9]_.[0-9]_.json
+
+# dotenv environment variable files
+.env
+.env.development.local
+.env.test.local
+.env.production.local
+.env.local
+
+# caches
+.eslintcache
+.cache
+*.tsbuildinfo
+
+# IntelliJ based IDEs
+.idea
+
+# Environment variables
+.env*

--- a/README.md
+++ b/README.md
@@ -1,2 +1,31 @@
-# typescript-external-match-client
-A TypeScript client for the Renegade external match API
+# Renegade External Match Client
+
+A TypeScript client for interacting with the Renegade Darkpool's External Match API.
+
+## Installation
+
+```bash
+# Using npm
+npm install renegade-sdk
+
+# Using yarn
+yarn add renegade-sdk
+
+# Using bun
+bun add renegade-sdk
+```
+
+## Usage
+
+See the [examples](examples) for usage examples.
+
+## Documentation
+
+See the following resources for more information:
+- [Examples From the Existing SDK](https://github.com/renegade-fi/typescript-sdk/tree/main/examples)
+- [Renegade Docs](https://docs.renegade.fi/technical-reference/typescript-sdk#external-atomic-matching)
+- [OpenAPI spec](https://github.com/renegade-fi/renegade-docs/blob/main/api-specs/external-match-openapi.yaml)
+
+## License
+
+MIT

--- a/bun.lock
+++ b/bun.lock
@@ -1,0 +1,108 @@
+{
+  "lockfileVersion": 1,
+  "workspaces": {
+    "": {
+      "name": "renegade-sdk",
+      "dependencies": {
+        "@noble/hashes": "^1.7.1",
+        "axios": "^1.8.4",
+        "json-bigint": "^1.0.0",
+      },
+      "devDependencies": {
+        "@types/bun": "latest",
+        "@types/json-bigint": "^1.0.4",
+        "typescript": "^5",
+        "viem": "^2.23.15",
+      },
+    },
+  },
+  "packages": {
+    "@adraffy/ens-normalize": ["@adraffy/ens-normalize@1.11.0", "", {}, "sha512-/3DDPKHqqIqxUULp8yP4zODUY1i+2xvVWsv8A79xGWdCAG+8sb0hRh0Rk2QyOJUnnbyPUAZYcpBuRe3nS2OIUg=="],
+
+    "@noble/curves": ["@noble/curves@1.8.1", "", { "dependencies": { "@noble/hashes": "1.7.1" } }, "sha512-warwspo+UYUPep0Q+vtdVB4Ugn8GGQj8iyB3gnRWsztmUHTI3S1nhdiWNsPUGL0vud7JlRRk1XEu7Lq1KGTnMQ=="],
+
+    "@noble/hashes": ["@noble/hashes@1.7.1", "", {}, "sha512-B8XBPsn4vT/KJAGqDzbwztd+6Yte3P4V7iafm24bxgDe/mlRuK6xmWPuCNrKt2vDafZ8MfJLlchDG/vYafQEjQ=="],
+
+    "@scure/base": ["@scure/base@1.2.4", "", {}, "sha512-5Yy9czTO47mqz+/J8GM6GIId4umdCk1wc1q8rKERQulIoc8VP9pzDcghv10Tl2E7R96ZUx/PhND3ESYUQX8NuQ=="],
+
+    "@scure/bip32": ["@scure/bip32@1.6.2", "", { "dependencies": { "@noble/curves": "~1.8.1", "@noble/hashes": "~1.7.1", "@scure/base": "~1.2.2" } }, "sha512-t96EPDMbtGgtb7onKKqxRLfE5g05k7uHnHRM2xdE6BP/ZmxaLtPek4J4KfVn/90IQNrU1IOAqMgiDtUdtbe3nw=="],
+
+    "@scure/bip39": ["@scure/bip39@1.5.4", "", { "dependencies": { "@noble/hashes": "~1.7.1", "@scure/base": "~1.2.4" } }, "sha512-TFM4ni0vKvCfBpohoh+/lY05i9gRbSwXWngAsF4CABQxoaOHijxuaZ2R6cStDQ5CHtHO9aGJTr4ksVJASRRyMA=="],
+
+    "@types/bun": ["@types/bun@1.2.6", "", { "dependencies": { "bun-types": "1.2.6" } }, "sha512-fY9CAmTdJH1Llx7rugB0FpgWK2RKuHCs3g2cFDYXUutIy1QGiPQxKkGY8owhfZ4MXWNfxwIbQLChgH5gDsY7vw=="],
+
+    "@types/json-bigint": ["@types/json-bigint@1.0.4", "", {}, "sha512-ydHooXLbOmxBbubnA7Eh+RpBzuaIiQjh8WGJYQB50JFGFrdxW7JzVlyEV7fAXw0T2sqJ1ysTneJbiyNLqZRAag=="],
+
+    "@types/node": ["@types/node@22.13.13", "", { "dependencies": { "undici-types": "~6.20.0" } }, "sha512-ClsL5nMwKaBRwPcCvH8E7+nU4GxHVx1axNvMZTFHMEfNI7oahimt26P5zjVCRrjiIWj6YFXfE1v3dEp94wLcGQ=="],
+
+    "@types/ws": ["@types/ws@8.5.14", "", { "dependencies": { "@types/node": "*" } }, "sha512-bd/YFLW+URhBzMXurx7lWByOu+xzU9+kb3RboOteXYDfW+tr+JZa99OyNmPINEGB/ahzKrEuc8rcv4gnpJmxTw=="],
+
+    "abitype": ["abitype@1.0.8", "", { "peerDependencies": { "typescript": ">=5.0.4", "zod": "^3 >=3.22.0" }, "optionalPeers": ["typescript", "zod"] }, "sha512-ZeiI6h3GnW06uYDLx0etQtX/p8E24UaHHBj57RSjK7YBFe7iuVn07EDpOeP451D06sF27VOz9JJPlIKJmXgkEg=="],
+
+    "asynckit": ["asynckit@0.4.0", "", {}, "sha512-Oei9OH4tRh0YqU3GxhX79dM/mwVgvbZJaSNaRk+bshkj0S5cfHcgYakreBjrHwatXKbz+IoIdYLxrKim2MjW0Q=="],
+
+    "axios": ["axios@1.8.4", "", { "dependencies": { "follow-redirects": "^1.15.6", "form-data": "^4.0.0", "proxy-from-env": "^1.1.0" } }, "sha512-eBSYY4Y68NNlHbHBMdeDmKNtDgXWhQsJcGqzO3iLUM0GraQFSS9cVgPX5I9b3lbdFKyYoAEGAZF1DwhTaljNAw=="],
+
+    "bignumber.js": ["bignumber.js@9.1.2", "", {}, "sha512-2/mKyZH9K85bzOEfhXDBFZTGd1CTs+5IHpeFQo9luiBG7hghdC851Pj2WAhb6E3R6b9tZj/XKhbg4fum+Kepug=="],
+
+    "bun-types": ["bun-types@1.2.6", "", { "dependencies": { "@types/node": "*", "@types/ws": "~8.5.10" } }, "sha512-FbCKyr5KDiPULUzN/nm5oqQs9nXCHD8dVc64BArxJadCvbNzAI6lUWGh9fSJZWeDIRD38ikceBU8Kj/Uh+53oQ=="],
+
+    "call-bind-apply-helpers": ["call-bind-apply-helpers@1.0.2", "", { "dependencies": { "es-errors": "^1.3.0", "function-bind": "^1.1.2" } }, "sha512-Sp1ablJ0ivDkSzjcaJdxEunN5/XvksFJ2sMBFfq6x0ryhQV/2b/KwFe21cMpmHtPOSij8K99/wSfoEuTObmuMQ=="],
+
+    "combined-stream": ["combined-stream@1.0.8", "", { "dependencies": { "delayed-stream": "~1.0.0" } }, "sha512-FQN4MRfuJeHf7cBbBMJFXhKSDq+2kAArBlmRBvcvFE5BB1HZKXtSFASDhdlz9zOYwxh8lDdnvmMOe/+5cdoEdg=="],
+
+    "delayed-stream": ["delayed-stream@1.0.0", "", {}, "sha512-ZySD7Nf91aLB0RxL4KGrKHBXl7Eds1DAmEdcoVawXnLD7SDhpNgtuII2aAkg7a7QS41jxPSZ17p4VdGnMHk3MQ=="],
+
+    "dunder-proto": ["dunder-proto@1.0.1", "", { "dependencies": { "call-bind-apply-helpers": "^1.0.1", "es-errors": "^1.3.0", "gopd": "^1.2.0" } }, "sha512-KIN/nDJBQRcXw0MLVhZE9iQHmG68qAVIBg9CqmUYjmQIhgij9U5MFvrqkUL5FbtyyzZuOeOt0zdeRe4UY7ct+A=="],
+
+    "es-define-property": ["es-define-property@1.0.1", "", {}, "sha512-e3nRfgfUZ4rNGL232gUgX06QNyyez04KdjFrF+LTRoOXmrOgFKDg4BCdsjW8EnT69eqdYGmRpJwiPVYNrCaW3g=="],
+
+    "es-errors": ["es-errors@1.3.0", "", {}, "sha512-Zf5H2Kxt2xjTvbJvP2ZWLEICxA6j+hAmMzIlypy4xcBg1vKVnx89Wy0GbS+kf5cwCVFFzdCFh2XSCFNULS6csw=="],
+
+    "es-object-atoms": ["es-object-atoms@1.1.1", "", { "dependencies": { "es-errors": "^1.3.0" } }, "sha512-FGgH2h8zKNim9ljj7dankFPcICIK9Cp5bm+c2gQSYePhpaG5+esrLODihIorn+Pe6FGJzWhXQotPv73jTaldXA=="],
+
+    "es-set-tostringtag": ["es-set-tostringtag@2.1.0", "", { "dependencies": { "es-errors": "^1.3.0", "get-intrinsic": "^1.2.6", "has-tostringtag": "^1.0.2", "hasown": "^2.0.2" } }, "sha512-j6vWzfrGVfyXxge+O0x5sh6cvxAog0a/4Rdd2K36zCMV5eJ+/+tOAngRO8cODMNWbVRdVlmGZQL2YS3yR8bIUA=="],
+
+    "eventemitter3": ["eventemitter3@5.0.1", "", {}, "sha512-GWkBvjiSZK87ELrYOSESUYeVIc9mvLLf/nXalMOS5dYrgZq9o5OVkbZAVM06CVxYsCwH9BDZFPlQTlPA1j4ahA=="],
+
+    "follow-redirects": ["follow-redirects@1.15.9", "", {}, "sha512-gew4GsXizNgdoRyqmyfMHyAmXsZDk6mHkSxZFCzW9gwlbtOW44CDtYavM+y+72qD/Vq2l550kMF52DT8fOLJqQ=="],
+
+    "form-data": ["form-data@4.0.2", "", { "dependencies": { "asynckit": "^0.4.0", "combined-stream": "^1.0.8", "es-set-tostringtag": "^2.1.0", "mime-types": "^2.1.12" } }, "sha512-hGfm/slu0ZabnNt4oaRZ6uREyfCj6P4fT/n6A1rGV+Z0VdGXjfOhVUpkn6qVQONHGIFwmveGXyDs75+nr6FM8w=="],
+
+    "function-bind": ["function-bind@1.1.2", "", {}, "sha512-7XHNxH7qX9xG5mIwxkhumTox/MIRNcOgDrxWsMt2pAr23WHp6MrRlN7FBSFpCpr+oVO0F744iUgR82nJMfG2SA=="],
+
+    "get-intrinsic": ["get-intrinsic@1.3.0", "", { "dependencies": { "call-bind-apply-helpers": "^1.0.2", "es-define-property": "^1.0.1", "es-errors": "^1.3.0", "es-object-atoms": "^1.1.1", "function-bind": "^1.1.2", "get-proto": "^1.0.1", "gopd": "^1.2.0", "has-symbols": "^1.1.0", "hasown": "^2.0.2", "math-intrinsics": "^1.1.0" } }, "sha512-9fSjSaos/fRIVIp+xSJlE6lfwhES7LNtKaCBIamHsjr2na1BiABJPo0mOjjz8GJDURarmCPGqaiVg5mfjb98CQ=="],
+
+    "get-proto": ["get-proto@1.0.1", "", { "dependencies": { "dunder-proto": "^1.0.1", "es-object-atoms": "^1.0.0" } }, "sha512-sTSfBjoXBp89JvIKIefqw7U2CCebsc74kiY6awiGogKtoSGbgjYE/G/+l9sF3MWFPNc9IcoOC4ODfKHfxFmp0g=="],
+
+    "gopd": ["gopd@1.2.0", "", {}, "sha512-ZUKRh6/kUFoAiTAtTYPZJ3hw9wNxx+BIBOijnlG9PnrJsCcSjs1wyyD6vJpaYtgnzDrKYRSqf3OO6Rfa93xsRg=="],
+
+    "has-symbols": ["has-symbols@1.1.0", "", {}, "sha512-1cDNdwJ2Jaohmb3sg4OmKaMBwuC48sYni5HUw2DvsC8LjGTLK9h+eb1X6RyuOHe4hT0ULCW68iomhjUoKUqlPQ=="],
+
+    "has-tostringtag": ["has-tostringtag@1.0.2", "", { "dependencies": { "has-symbols": "^1.0.3" } }, "sha512-NqADB8VjPFLM2V0VvHUewwwsw0ZWBaIdgo+ieHtK3hasLz4qeCRjYcqfB6AQrBggRKppKF8L52/VqdVsO47Dlw=="],
+
+    "hasown": ["hasown@2.0.2", "", { "dependencies": { "function-bind": "^1.1.2" } }, "sha512-0hJU9SCPvmMzIBdZFqNPXWa6dqh7WdH0cII9y+CyS8rG3nL48Bclra9HmKhVVUHyPWNH5Y7xDwAB7bfgSjkUMQ=="],
+
+    "isows": ["isows@1.0.6", "", { "peerDependencies": { "ws": "*" } }, "sha512-lPHCayd40oW98/I0uvgaHKWCSvkzY27LjWLbtzOm64yQ+G3Q5npjjbdppU65iZXkK1Zt+kH9pfegli0AYfwYYw=="],
+
+    "json-bigint": ["json-bigint@1.0.0", "", { "dependencies": { "bignumber.js": "^9.0.0" } }, "sha512-SiPv/8VpZuWbvLSMtTDU8hEfrZWg/mH/nV/b4o0CYbSxu1UIQPLdwKOCIyLQX+VIPO5vrLX3i8qtqFyhdPSUSQ=="],
+
+    "math-intrinsics": ["math-intrinsics@1.1.0", "", {}, "sha512-/IXtbwEk5HTPyEwyKX6hGkYXxM9nbj64B+ilVJnC/R6B0pH5G4V3b0pVbL7DBj4tkhBAppbQUlf6F6Xl9LHu1g=="],
+
+    "mime-db": ["mime-db@1.52.0", "", {}, "sha512-sPU4uV7dYlvtWJxwwxHD0PuihVNiE7TyAbQ5SWxDCB9mUYvOgroQOwYQQOKPJ8CIbE+1ETVlOoK1UC2nU3gYvg=="],
+
+    "mime-types": ["mime-types@2.1.35", "", { "dependencies": { "mime-db": "1.52.0" } }, "sha512-ZDY+bPm5zTTF+YpCrAU9nK0UgICYPT0QtT1NZWFv4s++TNkcgVaT0g6+4R2uI4MjQjzysHB1zxuWL50hzaeXiw=="],
+
+    "ox": ["ox@0.6.9", "", { "dependencies": { "@adraffy/ens-normalize": "^1.10.1", "@noble/curves": "^1.6.0", "@noble/hashes": "^1.5.0", "@scure/bip32": "^1.5.0", "@scure/bip39": "^1.4.0", "abitype": "^1.0.6", "eventemitter3": "5.0.1" }, "peerDependencies": { "typescript": ">=5.4.0" }, "optionalPeers": ["typescript"] }, "sha512-wi5ShvzE4eOcTwQVsIPdFr+8ycyX+5le/96iAJutaZAvCes1J0+RvpEPg5QDPDiaR0XQQAvZVl7AwqQcINuUug=="],
+
+    "proxy-from-env": ["proxy-from-env@1.1.0", "", {}, "sha512-D+zkORCbA9f1tdWRK0RaCR3GPv50cMxcrz4X8k5LTSUD1Dkw47mKJEZQNunItRTkWwgtaUSo1RVFRIG9ZXiFYg=="],
+
+    "typescript": ["typescript@5.8.2", "", { "bin": { "tsc": "bin/tsc", "tsserver": "bin/tsserver" } }, "sha512-aJn6wq13/afZp/jT9QZmwEjDqqvSGp1VT5GVg+f/t6/oVyrgXM6BY1h9BRh/O5p3PlUPAe+WuiEZOmb/49RqoQ=="],
+
+    "undici-types": ["undici-types@6.20.0", "", {}, "sha512-Ny6QZ2Nju20vw1SRHe3d9jVu6gJ+4e3+MMpqu7pqE5HT6WsTSlce++GQmK5UXS8mzV8DSYHrQH+Xrf2jVcuKNg=="],
+
+    "viem": ["viem@2.23.15", "", { "dependencies": { "@noble/curves": "1.8.1", "@noble/hashes": "1.7.1", "@scure/bip32": "1.6.2", "@scure/bip39": "1.5.4", "abitype": "1.0.8", "isows": "1.0.6", "ox": "0.6.9", "ws": "8.18.1" }, "peerDependencies": { "typescript": ">=5.0.4" }, "optionalPeers": ["typescript"] }, "sha512-2t9lROkSzj/ciEZ08NqAHZ6c+J1wKLwJ4qpUxcHdVHcLBt6GfO9+ycuZycTT05ckfJ6TbwnMXMa3bMonvhtUMw=="],
+
+    "ws": ["ws@8.18.1", "", { "peerDependencies": { "bufferutil": "^4.0.1", "utf-8-validate": ">=5.0.2" }, "optionalPeers": ["bufferutil", "utf-8-validate"] }, "sha512-RKW2aJZMXeMxVpnZ6bck+RswznaxmzdULiBr6KY7XkTnW8uvt0iT9H5DkHUChXrc+uurzwa0rVI16n/Xzjdz1w=="],
+  }
+}

--- a/bun.lock
+++ b/bun.lock
@@ -5,7 +5,6 @@
       "name": "renegade-sdk",
       "dependencies": {
         "@noble/hashes": "^1.7.1",
-        "axios": "^1.8.4",
         "json-bigint": "^1.0.0",
       },
       "devDependencies": {
@@ -39,63 +38,17 @@
 
     "abitype": ["abitype@1.0.8", "", { "peerDependencies": { "typescript": ">=5.0.4", "zod": "^3 >=3.22.0" }, "optionalPeers": ["typescript", "zod"] }, "sha512-ZeiI6h3GnW06uYDLx0etQtX/p8E24UaHHBj57RSjK7YBFe7iuVn07EDpOeP451D06sF27VOz9JJPlIKJmXgkEg=="],
 
-    "asynckit": ["asynckit@0.4.0", "", {}, "sha512-Oei9OH4tRh0YqU3GxhX79dM/mwVgvbZJaSNaRk+bshkj0S5cfHcgYakreBjrHwatXKbz+IoIdYLxrKim2MjW0Q=="],
-
-    "axios": ["axios@1.8.4", "", { "dependencies": { "follow-redirects": "^1.15.6", "form-data": "^4.0.0", "proxy-from-env": "^1.1.0" } }, "sha512-eBSYY4Y68NNlHbHBMdeDmKNtDgXWhQsJcGqzO3iLUM0GraQFSS9cVgPX5I9b3lbdFKyYoAEGAZF1DwhTaljNAw=="],
-
     "bignumber.js": ["bignumber.js@9.1.2", "", {}, "sha512-2/mKyZH9K85bzOEfhXDBFZTGd1CTs+5IHpeFQo9luiBG7hghdC851Pj2WAhb6E3R6b9tZj/XKhbg4fum+Kepug=="],
 
     "bun-types": ["bun-types@1.2.6", "", { "dependencies": { "@types/node": "*", "@types/ws": "~8.5.10" } }, "sha512-FbCKyr5KDiPULUzN/nm5oqQs9nXCHD8dVc64BArxJadCvbNzAI6lUWGh9fSJZWeDIRD38ikceBU8Kj/Uh+53oQ=="],
 
-    "call-bind-apply-helpers": ["call-bind-apply-helpers@1.0.2", "", { "dependencies": { "es-errors": "^1.3.0", "function-bind": "^1.1.2" } }, "sha512-Sp1ablJ0ivDkSzjcaJdxEunN5/XvksFJ2sMBFfq6x0ryhQV/2b/KwFe21cMpmHtPOSij8K99/wSfoEuTObmuMQ=="],
-
-    "combined-stream": ["combined-stream@1.0.8", "", { "dependencies": { "delayed-stream": "~1.0.0" } }, "sha512-FQN4MRfuJeHf7cBbBMJFXhKSDq+2kAArBlmRBvcvFE5BB1HZKXtSFASDhdlz9zOYwxh8lDdnvmMOe/+5cdoEdg=="],
-
-    "delayed-stream": ["delayed-stream@1.0.0", "", {}, "sha512-ZySD7Nf91aLB0RxL4KGrKHBXl7Eds1DAmEdcoVawXnLD7SDhpNgtuII2aAkg7a7QS41jxPSZ17p4VdGnMHk3MQ=="],
-
-    "dunder-proto": ["dunder-proto@1.0.1", "", { "dependencies": { "call-bind-apply-helpers": "^1.0.1", "es-errors": "^1.3.0", "gopd": "^1.2.0" } }, "sha512-KIN/nDJBQRcXw0MLVhZE9iQHmG68qAVIBg9CqmUYjmQIhgij9U5MFvrqkUL5FbtyyzZuOeOt0zdeRe4UY7ct+A=="],
-
-    "es-define-property": ["es-define-property@1.0.1", "", {}, "sha512-e3nRfgfUZ4rNGL232gUgX06QNyyez04KdjFrF+LTRoOXmrOgFKDg4BCdsjW8EnT69eqdYGmRpJwiPVYNrCaW3g=="],
-
-    "es-errors": ["es-errors@1.3.0", "", {}, "sha512-Zf5H2Kxt2xjTvbJvP2ZWLEICxA6j+hAmMzIlypy4xcBg1vKVnx89Wy0GbS+kf5cwCVFFzdCFh2XSCFNULS6csw=="],
-
-    "es-object-atoms": ["es-object-atoms@1.1.1", "", { "dependencies": { "es-errors": "^1.3.0" } }, "sha512-FGgH2h8zKNim9ljj7dankFPcICIK9Cp5bm+c2gQSYePhpaG5+esrLODihIorn+Pe6FGJzWhXQotPv73jTaldXA=="],
-
-    "es-set-tostringtag": ["es-set-tostringtag@2.1.0", "", { "dependencies": { "es-errors": "^1.3.0", "get-intrinsic": "^1.2.6", "has-tostringtag": "^1.0.2", "hasown": "^2.0.2" } }, "sha512-j6vWzfrGVfyXxge+O0x5sh6cvxAog0a/4Rdd2K36zCMV5eJ+/+tOAngRO8cODMNWbVRdVlmGZQL2YS3yR8bIUA=="],
-
     "eventemitter3": ["eventemitter3@5.0.1", "", {}, "sha512-GWkBvjiSZK87ELrYOSESUYeVIc9mvLLf/nXalMOS5dYrgZq9o5OVkbZAVM06CVxYsCwH9BDZFPlQTlPA1j4ahA=="],
-
-    "follow-redirects": ["follow-redirects@1.15.9", "", {}, "sha512-gew4GsXizNgdoRyqmyfMHyAmXsZDk6mHkSxZFCzW9gwlbtOW44CDtYavM+y+72qD/Vq2l550kMF52DT8fOLJqQ=="],
-
-    "form-data": ["form-data@4.0.2", "", { "dependencies": { "asynckit": "^0.4.0", "combined-stream": "^1.0.8", "es-set-tostringtag": "^2.1.0", "mime-types": "^2.1.12" } }, "sha512-hGfm/slu0ZabnNt4oaRZ6uREyfCj6P4fT/n6A1rGV+Z0VdGXjfOhVUpkn6qVQONHGIFwmveGXyDs75+nr6FM8w=="],
-
-    "function-bind": ["function-bind@1.1.2", "", {}, "sha512-7XHNxH7qX9xG5mIwxkhumTox/MIRNcOgDrxWsMt2pAr23WHp6MrRlN7FBSFpCpr+oVO0F744iUgR82nJMfG2SA=="],
-
-    "get-intrinsic": ["get-intrinsic@1.3.0", "", { "dependencies": { "call-bind-apply-helpers": "^1.0.2", "es-define-property": "^1.0.1", "es-errors": "^1.3.0", "es-object-atoms": "^1.1.1", "function-bind": "^1.1.2", "get-proto": "^1.0.1", "gopd": "^1.2.0", "has-symbols": "^1.1.0", "hasown": "^2.0.2", "math-intrinsics": "^1.1.0" } }, "sha512-9fSjSaos/fRIVIp+xSJlE6lfwhES7LNtKaCBIamHsjr2na1BiABJPo0mOjjz8GJDURarmCPGqaiVg5mfjb98CQ=="],
-
-    "get-proto": ["get-proto@1.0.1", "", { "dependencies": { "dunder-proto": "^1.0.1", "es-object-atoms": "^1.0.0" } }, "sha512-sTSfBjoXBp89JvIKIefqw7U2CCebsc74kiY6awiGogKtoSGbgjYE/G/+l9sF3MWFPNc9IcoOC4ODfKHfxFmp0g=="],
-
-    "gopd": ["gopd@1.2.0", "", {}, "sha512-ZUKRh6/kUFoAiTAtTYPZJ3hw9wNxx+BIBOijnlG9PnrJsCcSjs1wyyD6vJpaYtgnzDrKYRSqf3OO6Rfa93xsRg=="],
-
-    "has-symbols": ["has-symbols@1.1.0", "", {}, "sha512-1cDNdwJ2Jaohmb3sg4OmKaMBwuC48sYni5HUw2DvsC8LjGTLK9h+eb1X6RyuOHe4hT0ULCW68iomhjUoKUqlPQ=="],
-
-    "has-tostringtag": ["has-tostringtag@1.0.2", "", { "dependencies": { "has-symbols": "^1.0.3" } }, "sha512-NqADB8VjPFLM2V0VvHUewwwsw0ZWBaIdgo+ieHtK3hasLz4qeCRjYcqfB6AQrBggRKppKF8L52/VqdVsO47Dlw=="],
-
-    "hasown": ["hasown@2.0.2", "", { "dependencies": { "function-bind": "^1.1.2" } }, "sha512-0hJU9SCPvmMzIBdZFqNPXWa6dqh7WdH0cII9y+CyS8rG3nL48Bclra9HmKhVVUHyPWNH5Y7xDwAB7bfgSjkUMQ=="],
 
     "isows": ["isows@1.0.6", "", { "peerDependencies": { "ws": "*" } }, "sha512-lPHCayd40oW98/I0uvgaHKWCSvkzY27LjWLbtzOm64yQ+G3Q5npjjbdppU65iZXkK1Zt+kH9pfegli0AYfwYYw=="],
 
     "json-bigint": ["json-bigint@1.0.0", "", { "dependencies": { "bignumber.js": "^9.0.0" } }, "sha512-SiPv/8VpZuWbvLSMtTDU8hEfrZWg/mH/nV/b4o0CYbSxu1UIQPLdwKOCIyLQX+VIPO5vrLX3i8qtqFyhdPSUSQ=="],
 
-    "math-intrinsics": ["math-intrinsics@1.1.0", "", {}, "sha512-/IXtbwEk5HTPyEwyKX6hGkYXxM9nbj64B+ilVJnC/R6B0pH5G4V3b0pVbL7DBj4tkhBAppbQUlf6F6Xl9LHu1g=="],
-
-    "mime-db": ["mime-db@1.52.0", "", {}, "sha512-sPU4uV7dYlvtWJxwwxHD0PuihVNiE7TyAbQ5SWxDCB9mUYvOgroQOwYQQOKPJ8CIbE+1ETVlOoK1UC2nU3gYvg=="],
-
-    "mime-types": ["mime-types@2.1.35", "", { "dependencies": { "mime-db": "1.52.0" } }, "sha512-ZDY+bPm5zTTF+YpCrAU9nK0UgICYPT0QtT1NZWFv4s++TNkcgVaT0g6+4R2uI4MjQjzysHB1zxuWL50hzaeXiw=="],
-
     "ox": ["ox@0.6.9", "", { "dependencies": { "@adraffy/ens-normalize": "^1.10.1", "@noble/curves": "^1.6.0", "@noble/hashes": "^1.5.0", "@scure/bip32": "^1.5.0", "@scure/bip39": "^1.4.0", "abitype": "^1.0.6", "eventemitter3": "5.0.1" }, "peerDependencies": { "typescript": ">=5.4.0" }, "optionalPeers": ["typescript"] }, "sha512-wi5ShvzE4eOcTwQVsIPdFr+8ycyX+5le/96iAJutaZAvCes1J0+RvpEPg5QDPDiaR0XQQAvZVl7AwqQcINuUug=="],
-
-    "proxy-from-env": ["proxy-from-env@1.1.0", "", {}, "sha512-D+zkORCbA9f1tdWRK0RaCR3GPv50cMxcrz4X8k5LTSUD1Dkw47mKJEZQNunItRTkWwgtaUSo1RVFRIG9ZXiFYg=="],
 
     "typescript": ["typescript@5.8.2", "", { "bin": { "tsc": "bin/tsc", "tsserver": "bin/tsserver" } }, "sha512-aJn6wq13/afZp/jT9QZmwEjDqqvSGp1VT5GVg+f/t6/oVyrgXM6BY1h9BRh/O5p3PlUPAe+WuiEZOmb/49RqoQ=="],
 

--- a/examples/basic.ts
+++ b/examples/basic.ts
@@ -63,7 +63,6 @@ const order: ExternalOrder = {
  */
 async function submitTransaction(settlementTx: any): Promise<`0x${string}`> {
     console.log('Submitting transaction...');
-    console.log('Transaction details:', settlementTx);
 
     const tx = await walletClient.sendTransaction({
         to: settlementTx.to as `0x${string}`,

--- a/examples/basic.ts
+++ b/examples/basic.ts
@@ -1,0 +1,122 @@
+/**
+ * Basic example of using the Renegade External Match Client
+ * 
+ * This example demonstrates how to create a client, request a quote, assemble a match, and submit the transaction on-chain.
+ */
+
+import {
+    ExternalMatchClient,
+    OrderSide,
+} from '../index';
+import type { ExternalOrder } from '../index';
+import { stringifyBigJSON } from '../src/http';
+
+// Viem imports for on-chain transactions
+import { http, createWalletClient } from 'viem';
+import { privateKeyToAccount } from 'viem/accounts';
+import { arbitrumSepolia } from 'viem/chains';
+
+// Get API credentials from environment variables
+const API_KEY = process.env.EXTERNAL_MATCH_KEY || '';
+const API_SECRET = process.env.EXTERNAL_MATCH_SECRET || '';
+const PRIVATE_KEY = process.env.PKEY || '';
+const RPC_URL = process.env.RPC_URL || 'https://sepolia-rollup.arbitrum.io/rpc';
+
+// Validate API credentials
+if (!API_KEY || !API_SECRET) {
+    console.error('Error: Missing API credentials');
+    console.error('Please set EXTERNAL_MATCH_KEY and EXTERNAL_MATCH_SECRET environment variables');
+    process.exit(1);
+}
+
+// Validate wallet private key
+if (!PRIVATE_KEY) {
+    console.error('Error: Missing private key');
+    console.error('Please set PRIVATE_KEY environment variable');
+    process.exit(1);
+}
+
+// Set up wallet client for blockchain transactions
+const privateKey = PRIVATE_KEY.startsWith('0x') ? PRIVATE_KEY : `0x${PRIVATE_KEY}`;
+const walletClient = createWalletClient({
+    account: privateKeyToAccount(privateKey as `0x${string}`),
+    chain: arbitrumSepolia,
+    transport: http(RPC_URL),
+});
+
+// Create the external match client
+console.log('API KEY', API_KEY);
+const client = ExternalMatchClient.newSepoliaClient(API_KEY, API_SECRET);
+
+// Example order for USDC/WETH pair
+const order: ExternalOrder = {
+    quote_mint: '0xdf8d259c04020562717557f2b5a3cf28e92707d1', // USDC
+    base_mint: '0xc3414a7ef14aaaa9c4522dfc00a4e66e74e9c25a',  // WETH
+    side: OrderSide.BUY,
+    quote_amount: BigInt(20_000_000), // 20 USDC
+};
+
+/**
+ * Submit a transaction to the chain
+ * @param settlementTx The settlement transaction
+ * @returns The transaction hash
+ */
+async function submitTransaction(settlementTx: any): Promise<`0x${string}`> {
+    console.log('Submitting transaction...');
+    console.log('Transaction details:', settlementTx);
+
+    const tx = await walletClient.sendTransaction({
+        to: settlementTx.to as `0x${string}`,
+        data: settlementTx.data as `0x${string}`,
+        value: settlementTx.value ? BigInt(settlementTx.value) : BigInt(0),
+    });
+
+    return tx;
+}
+
+// Full example with on-chain submission
+async function fullExample() {
+    try {
+        // Step 1: Request a quote
+        console.log('Requesting quote...');
+        const quote = await client.requestQuote(order);
+
+        if (!quote) {
+            console.log('No quote available');
+            return;
+        }
+
+        console.log('Quote received!');
+
+        // Step 2: Assemble the quote into a match bundle
+        console.log('Assembling match...');
+        const bundle = await client.assembleQuote(quote);
+
+        if (!bundle) {
+            console.log('No match available');
+            return;
+        }
+
+        console.log('Match assembled!');
+
+        // Step 3: Submit the transaction on-chain
+        const txHash = await submitTransaction(bundle.match_bundle.settlement_tx);
+        console.log(
+            'Transaction submitted:',
+            `${walletClient.chain.blockExplorers?.default.url}/tx/${txHash}`
+        );
+    } catch (error) {
+        console.error('Error:', error);
+    }
+}
+
+// Run the examples
+async function main() {
+    console.log('Running full example with on-chain submission...');
+    await fullExample();
+}
+
+// Only run if this file is being executed directly
+if (require.main === module) {
+    main().catch(console.error);
+} 

--- a/index.ts
+++ b/index.ts
@@ -1,0 +1,30 @@
+/**
+ * Renegade External Match Client
+ * A TypeScript client for interacting with the Renegade Darkpool API.
+ */
+
+// Export main client
+export { ExternalMatchClient, ExternalMatchClientError, RequestQuoteOptions, AssembleExternalMatchOptions } from './src/client';
+
+// Export types
+export type {
+    ApiExternalAssetTransfer,
+    ApiTimestampedPrice,
+    ApiExternalMatchResult,
+    FeeTake,
+    ExternalOrder,
+    ApiExternalQuote,
+    ApiSignedExternalQuote,
+    GasSponsorshipInfo,
+    SignedGasSponsorshipInfo,
+    SignedExternalQuote,
+    SettlementTransaction,
+    AtomicMatchApiBundle,
+    ExternalQuoteRequest,
+    ExternalQuoteResponse,
+    AssembleExternalMatchRequest,
+    ExternalMatchResponse
+} from './src/types';
+
+// Export enums
+export { OrderSide } from './src/types';

--- a/package.json
+++ b/package.json
@@ -24,7 +24,6 @@
   "license": "MIT",
   "dependencies": {
     "@noble/hashes": "^1.7.1",
-    "axios": "^1.8.4",
     "json-bigint": "^1.0.0"
   },
   "devDependencies": {

--- a/package.json
+++ b/package.json
@@ -1,0 +1,43 @@
+{
+  "name": "renegade-sdk",
+  "version": "0.1.0",
+  "description": "A TypeScript client for interacting with the Renegade Darkpool API",
+  "module": "index.ts",
+  "type": "module",
+  "main": "dist/index.js",
+  "types": "dist/index.d.ts",
+  "scripts": {
+    "build": "tsc -p tsconfig.build.json",
+    "update-version": "bash scripts/update-version.sh",
+    "prepublishOnly": "npm run update-version && npm run build"
+  },
+  "keywords": [
+    "renegade",
+    "darkpool",
+    "trading",
+    "api",
+    "client",
+    "cryptocurrency",
+    "defi"
+  ],
+  "author": "Renegade",
+  "license": "MIT",
+  "dependencies": {
+    "@noble/hashes": "^1.7.1",
+    "axios": "^1.8.4",
+    "json-bigint": "^1.0.0"
+  },
+  "devDependencies": {
+    "@types/bun": "latest",
+    "@types/json-bigint": "^1.0.4",
+    "typescript": "^5",
+    "viem": "^2.23.15"
+  },
+  "repository": {
+    "type": "git",
+    "url": "https://github.com/renegade-fi/typescript-external-match-client"
+  },
+  "engines": {
+    "node": ">=18"
+  }
+}

--- a/scripts/update-version.sh
+++ b/scripts/update-version.sh
@@ -1,0 +1,30 @@
+#!/bin/bash
+
+# Script to update the SDK version in the version.ts file
+# This should be run as part of the prepublishOnly npm script
+
+set -e
+
+# Get the package version from package.json using jq
+VERSION=$(jq -r '.version' package.json)
+
+if [ -z "$VERSION" ]; then
+  echo "Error: Could not find version in package.json"
+  exit 1
+fi
+
+# Path to version.ts file
+VERSION_FILE="src/version.ts"
+
+# Generate version file content
+cat > $VERSION_FILE << EOF
+/**
+ * SDK version information
+ * This file is automatically updated during the build process
+ * Last updated: $(date -u +"%Y-%m-%dT%H:%M:%SZ")
+ */
+
+export const VERSION = '$VERSION';
+EOF
+
+echo "Successfully updated version to $VERSION in $VERSION_FILE" 

--- a/src/client.ts
+++ b/src/client.ts
@@ -1,0 +1,364 @@
+/**
+ * Client for interacting with the Renegade external matching API.
+ * 
+ * This client handles authentication and provides methods for requesting quotes,
+ * assembling matches, and executing trades.
+ */
+
+import { RelayerHttpClient, RENEGADE_HEADER_PREFIX } from './http';
+import { VERSION } from './version';
+import type {
+    ExternalOrder,
+    SignedExternalQuote,
+    ExternalQuoteRequest,
+    ExternalQuoteResponse,
+    AssembleExternalMatchRequest,
+    ExternalMatchResponse,
+    ApiSignedExternalQuote,
+    AtomicMatchApiBundle
+} from './types';
+
+// Constants for API URLs
+const SEPOLIA_BASE_URL = "https://testnet.auth-server.renegade.fi";
+const MAINNET_BASE_URL = "https://mainnet.auth-server.renegade.fi";
+
+// Header constants
+const RENEGADE_API_KEY_HEADER = "x-renegade-api-key";
+const RENEGADE_SDK_VERSION_HEADER = "x-renegade-sdk-version";
+
+// API Routes
+const REQUEST_EXTERNAL_QUOTE_ROUTE = "/v0/matching-engine/quote";
+const ASSEMBLE_EXTERNAL_MATCH_ROUTE = "/v0/matching-engine/assemble-external-match";
+
+// Query Parameters
+const DISABLE_GAS_SPONSORSHIP_QUERY_PARAM = "disable_gas_sponsorship";
+const GAS_REFUND_ADDRESS_QUERY_PARAM = "refund_address";
+const REFUND_NATIVE_ETH_QUERY_PARAM = "refund_native_eth";
+
+/**
+ * Get the SDK version string.
+ * 
+ * @returns The SDK version prefixed with "typescript-v"
+ */
+function getSdkVersion(): string {
+    return `typescript-v${VERSION}`;
+}
+
+/**
+ * Options for requesting a quote.
+ */
+export class RequestQuoteOptions {
+    disableGasSponsorship: boolean = false;
+    gasRefundAddress?: string;
+    refundNativeEth: boolean = false;
+
+    /**
+     * Create a new instance of RequestQuoteOptions.
+     */
+    static new(): RequestQuoteOptions {
+        return new RequestQuoteOptions();
+    }
+
+    /**
+     * Set whether gas sponsorship should be disabled.
+     */
+    withGasSponsorshipDisabled(disableGasSponsorship: boolean): RequestQuoteOptions {
+        this.disableGasSponsorship = disableGasSponsorship;
+        return this;
+    }
+
+    /**
+     * Set the gas refund address.
+     */
+    withGasRefundAddress(gasRefundAddress: string): RequestQuoteOptions {
+        this.gasRefundAddress = gasRefundAddress;
+        return this;
+    }
+
+    /**
+     * Set whether to refund in native ETH.
+     */
+    withRefundNativeEth(refundNativeEth: boolean): RequestQuoteOptions {
+        this.refundNativeEth = refundNativeEth;
+        return this;
+    }
+
+    /**
+     * Build the request path with query parameters.
+     */
+    buildRequestPath(): string {
+        const disableSponsorshipStr = this.disableGasSponsorship.toString();
+        let path = `${REQUEST_EXTERNAL_QUOTE_ROUTE}?${DISABLE_GAS_SPONSORSHIP_QUERY_PARAM}=${disableSponsorshipStr}`;
+
+        if (this.gasRefundAddress) {
+            path += `&${GAS_REFUND_ADDRESS_QUERY_PARAM}=${this.gasRefundAddress}`;
+        }
+
+        if (this.refundNativeEth) {
+            const refundNativeEthStr = this.refundNativeEth.toString();
+            path += `&${REFUND_NATIVE_ETH_QUERY_PARAM}=${refundNativeEthStr}`;
+        }
+
+        return path;
+    }
+}
+
+/**
+ * Options for assembling an external match.
+ */
+export class AssembleExternalMatchOptions {
+    doGasEstimation: boolean = false;
+    receiverAddress?: string;
+    updatedOrder?: ExternalOrder;
+    requestGasSponsorship: boolean = false;
+    gasRefundAddress?: string;
+
+    /**
+     * Create a new instance of AssembleExternalMatchOptions.
+     */
+    static new(): AssembleExternalMatchOptions {
+        return new AssembleExternalMatchOptions();
+    }
+
+    /**
+     * Set whether to do gas estimation.
+     */
+    withGasEstimation(doGasEstimation: boolean): AssembleExternalMatchOptions {
+        this.doGasEstimation = doGasEstimation;
+        return this;
+    }
+
+    /**
+     * Set the receiver address.
+     */
+    withReceiverAddress(receiverAddress: string): AssembleExternalMatchOptions {
+        this.receiverAddress = receiverAddress;
+        return this;
+    }
+
+    /**
+     * Set the updated order.
+     */
+    withUpdatedOrder(updatedOrder: ExternalOrder): AssembleExternalMatchOptions {
+        this.updatedOrder = updatedOrder;
+        return this;
+    }
+
+    /**
+     * Set whether to request gas sponsorship.
+     * @deprecated Request gas sponsorship when requesting a quote instead
+     */
+    withGasSponsorship(requestGasSponsorship: boolean): AssembleExternalMatchOptions {
+        this.requestGasSponsorship = requestGasSponsorship;
+        return this;
+    }
+
+    /**
+     * Set the gas refund address.
+     * @deprecated Request gas sponsorship when requesting a quote instead
+     */
+    withGasRefundAddress(gasRefundAddress: string): AssembleExternalMatchOptions {
+        this.gasRefundAddress = gasRefundAddress;
+        return this;
+    }
+
+    /**
+     * Build the request path with query parameters.
+     */
+    buildRequestPath(): string {
+        let path = ASSEMBLE_EXTERNAL_MATCH_ROUTE;
+
+        if (this.requestGasSponsorship) {
+            // We only write this query parameter if it was explicitly set. The
+            // expectation of the auth server is that when gas sponsorship is
+            // requested at the quote stage, there should be no query parameters
+            // at all in the assemble request.
+            const disableSponsorshipStr = (!this.requestGasSponsorship).toString();
+            path += `?${DISABLE_GAS_SPONSORSHIP_QUERY_PARAM}=${disableSponsorshipStr}`;
+        }
+
+        if (this.gasRefundAddress) {
+            path += path.includes('?') ? '&' : '?';
+            path += `${GAS_REFUND_ADDRESS_QUERY_PARAM}=${this.gasRefundAddress}`;
+        }
+
+        return path;
+    }
+}
+
+/**
+ * Error thrown by the ExternalMatchClient.
+ */
+export class ExternalMatchClientError extends Error {
+    statusCode?: number;
+
+    constructor(message: string, statusCode?: number) {
+        super(message);
+        this.name = 'ExternalMatchClientError';
+        this.statusCode = statusCode;
+    }
+}
+
+/**
+ * Client for interacting with the Renegade external matching API.
+ */
+export class ExternalMatchClient {
+    private apiKey: string;
+    private httpClient: RelayerHttpClient;
+
+    /**
+     * Initialize a new ExternalMatchClient.
+     * 
+     * @param apiKey The API key for authentication
+     * @param apiSecret The API secret for request signing
+     * @param baseUrl The base URL of the Renegade API
+     */
+    constructor(apiKey: string, apiSecret: string, baseUrl: string) {
+        this.apiKey = apiKey;
+        this.httpClient = new RelayerHttpClient(baseUrl, apiSecret);
+    }
+
+    /**
+     * Create a new client configured for the Sepolia testnet.
+     * 
+     * @param apiKey The API key for authentication
+     * @param apiSecret The API secret for request signing
+     * @returns A new ExternalMatchClient configured for Sepolia
+     */
+    static newSepoliaClient(apiKey: string, apiSecret: string): ExternalMatchClient {
+        return new ExternalMatchClient(apiKey, apiSecret, SEPOLIA_BASE_URL);
+    }
+
+    /**
+     * Create a new client configured for mainnet.
+     * 
+     * @param apiKey The API key for authentication
+     * @param apiSecret The API secret for request signing
+     * @returns A new ExternalMatchClient configured for mainnet
+     */
+    static newMainnetClient(apiKey: string, apiSecret: string): ExternalMatchClient {
+        return new ExternalMatchClient(apiKey, apiSecret, MAINNET_BASE_URL);
+    }
+
+    /**
+     * Request a quote for the given order.
+     * 
+     * @param order The order to request a quote for
+     * @returns A promise that resolves to a signed quote if one is available, null otherwise
+     * @throws ExternalMatchClientError if the request fails
+     */
+    async requestQuote(order: ExternalOrder): Promise<SignedExternalQuote | null> {
+        return this.requestQuoteWithOptions(order, RequestQuoteOptions.new());
+    }
+
+    /**
+     * Request a quote for the given order with custom options.
+     * 
+     * @param order The order to request a quote for
+     * @param options Custom options for the quote request
+     * @returns A promise that resolves to a signed quote if one is available, null otherwise
+     * @throws ExternalMatchClientError if the request fails
+     */
+    async requestQuoteWithOptions(
+        order: ExternalOrder,
+        options: RequestQuoteOptions
+    ): Promise<SignedExternalQuote | null> {
+        const request: ExternalQuoteRequest = {
+            external_order: order
+        };
+
+        const path = options.buildRequestPath();
+        const headers = this.getHeaders();
+
+        try {
+            const response = await this.httpClient.post<ExternalQuoteResponse>(path, request, headers);
+            if (!response.data) {
+                return null;
+            }
+
+            const quoteResp = response.data;
+            const signedQuote: SignedExternalQuote = {
+                quote: quoteResp.signed_quote.quote,
+                signature: quoteResp.signed_quote.signature,
+                gas_sponsorship_info: quoteResp.gas_sponsorship_info
+            };
+
+            return signedQuote;
+        } catch (error: any) {
+            if (error.response && error.response.status === 204) {
+                return null;
+            }
+
+            throw new ExternalMatchClientError(
+                error.response?.data || error.message,
+                error.response?.status
+            );
+        }
+    }
+
+    /**
+     * Assemble a quote into a match bundle with default options.
+     * 
+     * @param quote The signed quote to assemble
+     * @returns A promise that resolves to a match response if assembly succeeds, null otherwise
+     * @throws ExternalMatchClientError if the request fails
+     */
+    async assembleQuote(quote: SignedExternalQuote): Promise<ExternalMatchResponse | null> {
+        return this.assembleQuoteWithOptions(quote, AssembleExternalMatchOptions.new());
+    }
+
+    /**
+     * Assemble a quote into a match bundle with custom options.
+     * 
+     * @param quote The signed quote to assemble
+     * @param options Custom options for quote assembly
+     * @returns A promise that resolves to a match response if assembly succeeds, null otherwise
+     * @throws ExternalMatchClientError if the request fails
+     */
+    async assembleQuoteWithOptions(
+        quote: SignedExternalQuote,
+        options: AssembleExternalMatchOptions
+    ): Promise<ExternalMatchResponse | null> {
+        const signedQuote: ApiSignedExternalQuote = {
+            quote: quote.quote,
+            signature: quote.signature,
+        };
+
+        const request: AssembleExternalMatchRequest = {
+            do_gas_estimation: options.doGasEstimation,
+            receiver_address: options.receiverAddress,
+            signed_quote: signedQuote,
+            updated_order: options.updatedOrder,
+            gas_sponsorship_info: quote.gas_sponsorship_info,
+        };
+
+        const path = options.buildRequestPath();
+        const headers = this.getHeaders();
+
+        try {
+            const response = await this.httpClient.post<ExternalMatchResponse>(path, request, headers);
+            return response.data;
+        } catch (error: any) {
+            if (error.response && error.response.status === 204) {
+                return null;
+            }
+
+            throw new ExternalMatchClientError(
+                error.response?.data || error.message,
+                error.response?.status
+            );
+        }
+    }
+
+    /**
+     * Get the headers required for API requests.
+     * 
+     * @returns Headers containing the API key and SDK version
+     */
+    private getHeaders(): Record<string, string> {
+        return {
+            [RENEGADE_API_KEY_HEADER]: this.apiKey,
+            [RENEGADE_SDK_VERSION_HEADER]: getSdkVersion(),
+        };
+    }
+}

--- a/src/http.ts
+++ b/src/http.ts
@@ -1,0 +1,173 @@
+/**
+ * HTTP client for making authenticated requests to the Renegade relayer API.
+ * This client handles request signing and authentication using HMAC-SHA256.
+ */
+
+import axios from 'axios';
+import type { AxiosInstance, AxiosRequestConfig, AxiosResponse, InternalAxiosRequestConfig, AxiosRequestHeaders } from 'axios';
+import { sha256 } from '@noble/hashes/sha256';
+import { hmac } from '@noble/hashes/hmac';
+import { bytesToHex } from '@noble/hashes/utils';
+import JSONBigInt from 'json-bigint';
+
+// Constants for authentication
+export const RENEGADE_HEADER_PREFIX = 'x-renegade';
+export const RENEGADE_AUTH_HEADER = 'x-renegade-auth';
+export const RENEGADE_AUTH_EXPIRATION_HEADER = 'x-renegade-auth-expiration';
+
+// Authentication constants
+const REQUEST_SIGNATURE_DURATION_MS = 10 * 1000; // 10 seconds in milliseconds
+
+// Configure JSON-BigInt for parsing and stringifying
+const jsonProcessor = JSONBigInt({
+    alwaysParseAsBig: true,
+    useNativeBigInt: true,
+});
+
+/**
+ * Parse JSON string that may contain BigInt values
+ */
+export const parseBigJSON = (data: string) => {
+    try {
+        return jsonProcessor.parse(data);
+    } catch (error) {
+        // If parsing fails, return original data
+        console.error('Failed to parse JSON with BigInt', error);
+        return data;
+    }
+};
+
+/**
+ * Stringify object that may contain BigInt values
+ */
+export const stringifyBigJSON = (data: any) => {
+    return jsonProcessor.stringify(data);
+};
+
+export class RelayerHttpClient {
+    private client: AxiosInstance;
+    private authKey: Uint8Array;
+
+    /**
+     * Initialize a new RelayerHttpClient.
+     * 
+     * @param baseUrl The base URL of the relayer API
+     * @param authKey The base64-encoded authentication key for request signing
+     */
+    constructor(baseUrl: string, authKey: string) {
+        this.client = axios.create({
+            baseURL: baseUrl,
+            transformRequest: [(data) => {
+                // Use JSON-BigInt for stringifying request data
+                if (data && typeof data === 'object') {
+                    return stringifyBigJSON(data);
+                }
+                return data;
+            }],
+            transformResponse: [(data) => {
+                // Use JSON-BigInt for parsing response data
+                if (typeof data === 'string') {
+                    return parseBigJSON(data);
+                }
+                return data;
+            }],
+            headers: {
+                'Content-Type': 'application/json'
+            }
+        });
+
+        // Decode base64 auth key
+        this.authKey = this.decodeBase64(authKey);
+
+        // Add request interceptor for authentication
+        this.client.interceptors.request.use(
+            this.addAuthInterceptor.bind(this),
+            (error) => Promise.reject(error)
+        );
+    }
+
+    /**
+     * Make a GET request with custom headers.
+     * 
+     * @param path The API endpoint path
+     * @param headers Additional headers to include
+     * @returns The API response
+     */
+    public async get<T>(path: string, headers: Record<string, string> = {}): Promise<AxiosResponse<T>> {
+        return this.client.get<T>(path, { headers });
+    }
+
+    /**
+     * Make a POST request with custom headers.
+     * 
+     * @param path The API endpoint path
+     * @param data The request body to send
+     * @param headers Additional headers to include
+     * @returns The API response
+     */
+    public async post<T, D = any>(path: string, data: D, headers: Record<string, string> = {}): Promise<AxiosResponse<T>> {
+        return this.client.post<T>(path, data, { headers });
+    }
+
+    /**
+     * Add authentication headers to a request.
+     */
+    private addAuthInterceptor(config: InternalAxiosRequestConfig): InternalAxiosRequestConfig {
+        // Create headers if they don't exist
+        if (!config.headers) {
+            config.headers = axios.defaults.headers.common as AxiosRequestHeaders;
+        }
+
+        // Add timestamp and expiry
+        const timestamp = Date.now();
+        const expiry = timestamp + REQUEST_SIGNATURE_DURATION_MS;
+        config.headers[RENEGADE_AUTH_EXPIRATION_HEADER] = expiry.toString();
+
+        // Calculate signature
+        const mac = hmac.create(sha256, this.authKey);
+
+        // Get the full path including query params (url is already relative to baseUrl)
+        const fullPath = config.url || '';
+        const pathBytes = new TextEncoder().encode(fullPath);
+        mac.update(pathBytes);
+
+        // Add Renegade headers
+        const headers = Object.entries(config.headers)
+            .filter(([key]) => key.toLowerCase().startsWith(RENEGADE_HEADER_PREFIX))
+            .filter(([key]) => key.toLowerCase() !== RENEGADE_AUTH_HEADER.toLowerCase())
+            .sort(([a], [b]) => a.localeCompare(b));
+
+        for (const [key, value] of headers) {
+            mac.update(new TextEncoder().encode(key));
+            mac.update(new TextEncoder().encode(value.toString()));
+        }
+
+        // Add body - use the same stringification as the request will use
+        let body = '';
+        if (config.data) {
+            body = typeof config.data === 'string'
+                ? config.data
+                : stringifyBigJSON(config.data);
+        }
+        mac.update(new TextEncoder().encode(body));
+
+        // Set signature header
+        config.headers[RENEGADE_AUTH_HEADER] = this.encodeBase64(Buffer.from(mac.digest()));
+
+        return config;
+    }
+
+    /**
+     * Decode a base64 string to a Uint8Array.
+     */
+    private decodeBase64(base64: string): Uint8Array {
+        return Buffer.from(base64, 'base64');
+    }
+
+    /**
+     * Encode a Uint8Array or Buffer to a base64 string.
+     */
+    private encodeBase64(data: Uint8Array | Buffer): string {
+        return Buffer.from(data).toString('base64').replace(/=+$/, '');
+    }
+} 

--- a/src/types.ts
+++ b/src/types.ts
@@ -1,0 +1,112 @@
+/**
+ * Type definitions for the Renegade Darkpool API.
+ */
+
+export enum OrderSide {
+    BUY = "Buy",
+    SELL = "Sell",
+}
+
+export interface ApiExternalAssetTransfer {
+    mint: string;
+    amount: bigint;
+}
+
+export interface ApiTimestampedPrice {
+    price: string;
+    timestamp: bigint;
+}
+
+export interface ApiExternalMatchResult {
+    quote_mint: string;
+    base_mint: string;
+    quote_amount: bigint;
+    base_amount: bigint;
+    direction: OrderSide;
+}
+
+export interface FeeTake {
+    relayer_fee: bigint;
+    protocol_fee: bigint;
+}
+
+export interface ExternalOrder {
+    quote_mint: string;
+    base_mint: string;
+    side: OrderSide;
+    base_amount?: bigint;
+    quote_amount?: bigint;
+    exact_base_output?: bigint;
+    exact_quote_output?: bigint;
+    min_fill_size?: bigint;
+}
+
+export interface ApiExternalQuote {
+    order: ExternalOrder;
+    match_result: ApiExternalMatchResult;
+    fees: FeeTake;
+    send: ApiExternalAssetTransfer;
+    receive: ApiExternalAssetTransfer;
+    price: ApiTimestampedPrice;
+    timestamp: bigint;
+}
+
+export interface ApiSignedExternalQuote {
+    quote: ApiExternalQuote;
+    signature: string;
+}
+
+export interface GasSponsorshipInfo {
+    refund_amount: bigint;
+    refund_native_eth: boolean;
+    refund_address?: string;
+}
+
+export interface SignedGasSponsorshipInfo {
+    gas_sponsorship_info: GasSponsorshipInfo;
+    signature: string;
+}
+
+export interface SignedExternalQuote {
+    quote: ApiExternalQuote;
+    signature: string;
+    gas_sponsorship_info?: SignedGasSponsorshipInfo;
+}
+
+export interface SettlementTransaction {
+    tx_type: string;
+    to: string;
+    data: string;
+    value: string;
+}
+
+export interface AtomicMatchApiBundle {
+    match_result: ApiExternalMatchResult;
+    fees: FeeTake;
+    receive: ApiExternalAssetTransfer;
+    send: ApiExternalAssetTransfer;
+    settlement_tx: SettlementTransaction;
+}
+
+export interface ExternalQuoteRequest {
+    external_order: ExternalOrder;
+}
+
+export interface ExternalQuoteResponse {
+    signed_quote: ApiSignedExternalQuote;
+    gas_sponsorship_info?: SignedGasSponsorshipInfo;
+}
+
+export interface AssembleExternalMatchRequest {
+    do_gas_estimation?: boolean;
+    receiver_address?: string;
+    signed_quote: ApiSignedExternalQuote;
+    updated_order?: ExternalOrder;
+    gas_sponsorship_info?: SignedGasSponsorshipInfo;
+}
+
+export interface ExternalMatchResponse {
+    match_bundle: AtomicMatchApiBundle;
+    gas_sponsored: boolean;
+    gas_sponsorship_info?: GasSponsorshipInfo;
+} 

--- a/src/version.ts
+++ b/src/version.ts
@@ -1,0 +1,7 @@
+/**
+ * SDK version information
+ * This file is automatically updated during the build process
+ * Last updated: 2025-03-26T20:22:47Z
+ */
+
+export const VERSION = '0.1.0';

--- a/tsconfig.build.json
+++ b/tsconfig.build.json
@@ -1,0 +1,17 @@
+{
+    "extends": "./tsconfig.json",
+    "compilerOptions": {
+        "outDir": "dist",
+        "declaration": true,
+        "noEmit": false,
+        "allowImportingTsExtensions": false
+    },
+    "include": [
+        "index.ts",
+        "src/**/*.ts"
+    ],
+    "exclude": [
+        "node_modules",
+        "**/*.test.ts"
+    ]
+}

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -1,0 +1,28 @@
+{
+  "compilerOptions": {
+    // Environment setup & latest features
+    "lib": ["esnext"],
+    "target": "ESNext",
+    "module": "ESNext",
+    "moduleDetection": "force",
+    "jsx": "react-jsx",
+    "allowJs": true,
+
+    // Bundler mode
+    "moduleResolution": "bundler",
+    "allowImportingTsExtensions": true,
+    "verbatimModuleSyntax": true,
+    "noEmit": true,
+
+    // Best practices
+    "strict": true,
+    "skipLibCheck": true,
+    "noFallthroughCasesInSwitch": true,
+    "noUncheckedIndexedAccess": true,
+
+    // Some stricter flags (disabled by default)
+    "noUnusedLocals": false,
+    "noUnusedParameters": false,
+    "noPropertyAccessFromIndexSignature": false
+  }
+}


### PR DESCRIPTION
### Purpose
This PR adds an initial implementation of the minimal typescript external match client -- broken out from the client embedded in `@renegade-fi/core`.

### Testing
- [x] Tested the example in `examples`