### PR TITLE
client, types: remove sponsorship info from assembly req

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@renegade-fi/renegade-sdk",
-  "version": "0.1.0",
+  "version": "0.1.1",
   "description": "A TypeScript client for interacting with the Renegade Darkpool API",
   "module": "index.ts",
   "type": "module",

--- a/src/client.ts
+++ b/src/client.ts
@@ -329,7 +329,6 @@ export class ExternalMatchClient {
             receiver_address: options.receiverAddress,
             signed_quote: signedQuote,
             updated_order: options.updatedOrder,
-            gas_sponsorship_info: quote.gas_sponsorship_info,
         };
 
         const path = options.buildRequestPath();

--- a/src/types.ts
+++ b/src/types.ts
@@ -102,7 +102,6 @@ export interface AssembleExternalMatchRequest {
     receiver_address?: string;
     signed_quote: ApiSignedExternalQuote;
     updated_order?: ExternalOrder;
-    gas_sponsorship_info?: SignedGasSponsorshipInfo;
 }
 
 export interface ExternalMatchResponse {

--- a/src/version.ts
+++ b/src/version.ts
@@ -1,7 +1,7 @@
 /**
  * SDK version information
  * This file is automatically updated during the build process
- * Last updated: 2025-03-27T00:13:04Z
+ * Last updated: 2025-04-04T16:34:13Z
  */
 
-export const VERSION = '0.1.0';
+export const VERSION = '0.1.1';


### PR DESCRIPTION
This PR removes the `gas_sponsorship_info` field from the quote assembly request.

### Testing
- [x] Ran the basic example, confirmed it behaved as expected