### PR TITLE
client, types: Expose `allow_shared` flag for match assembly

### DIFF
--- a/examples/shared_bundle.ts
+++ b/examples/shared_bundle.ts
@@ -1,0 +1,117 @@
+/**
+ * Basic example of using the Renegade External Match Client
+ * 
+ * This example demonstrates how to create a client, request a quote, assemble a match, and submit the transaction on-chain.
+ */
+
+import {
+    AssembleExternalMatchOptions,
+    ExternalMatchClient,
+    OrderSide,
+} from '../index';
+import type { ExternalOrder } from '../index';
+import { stringifyBigJSON } from '../src/http';
+
+// Viem imports for on-chain transactions
+import { http, createWalletClient } from 'viem';
+import { privateKeyToAccount } from 'viem/accounts';
+import { arbitrumSepolia } from 'viem/chains';
+
+// Get API credentials from environment variables
+const API_KEY = process.env.EXTERNAL_MATCH_KEY || '';
+const API_SECRET = process.env.EXTERNAL_MATCH_SECRET || '';
+const PRIVATE_KEY = process.env.PKEY || '';
+const RPC_URL = process.env.RPC_URL || 'https://sepolia-rollup.arbitrum.io/rpc';
+
+// Validate API credentials
+if (!API_KEY || !API_SECRET) {
+    console.error('Error: Missing API credentials');
+    console.error('Please set EXTERNAL_MATCH_KEY and EXTERNAL_MATCH_SECRET environment variables');
+    process.exit(1);
+}
+
+// Validate wallet private key
+if (!PRIVATE_KEY) {
+    console.error('Error: Missing private key');
+    console.error('Please set PRIVATE_KEY environment variable');
+    process.exit(1);
+}
+
+// Set up wallet client for blockchain transactions
+const privateKey = PRIVATE_KEY.startsWith('0x') ? PRIVATE_KEY : `0x${PRIVATE_KEY}`;
+const walletClient = createWalletClient({
+    account: privateKeyToAccount(privateKey as `0x${string}`),
+    chain: arbitrumSepolia,
+    transport: http(RPC_URL),
+});
+
+// Create the external match client
+console.log('API KEY', API_KEY);
+const client = ExternalMatchClient.newSepoliaClient(API_KEY, API_SECRET);
+
+// Example order for USDC/WETH pair
+const order: ExternalOrder = {
+    quote_mint: '0xdf8d259c04020562717557f2b5a3cf28e92707d1', // USDC
+    base_mint: '0xc3414a7ef14aaaa9c4522dfc00a4e66e74e9c25a',  // WETH
+    side: OrderSide.BUY,
+    quote_amount: BigInt(20_000_000), // 20 USDC
+};
+
+/**
+ * Submit a transaction to the chain
+ * @param settlementTx The settlement transaction
+ * @returns The transaction hash
+ */
+async function submitTransaction(settlementTx: any): Promise<`0x${string}`> {
+    console.log('Submitting transaction...');
+
+    const tx = await walletClient.sendTransaction({
+        to: settlementTx.to as `0x${string}`,
+        data: settlementTx.data as `0x${string}`,
+        value: settlementTx.value ? BigInt(settlementTx.value) : BigInt(0),
+    });
+
+    return tx;
+}
+
+// Run the examples
+async function main() {
+    try {
+        // Step 1: Request a quote
+        console.log('Requesting quote...');
+        const quote = await client.requestQuote(order);
+
+        if (!quote) {
+            console.log('No quote available');
+            return;
+        }
+
+        console.log('Quote received!');
+
+        // Step 2: Assemble the quote into a match bundle
+        console.log('Assembling match...');
+        const options = AssembleExternalMatchOptions.new().withAllowShared(true);
+        const bundle = await client.assembleQuoteWithOptions(quote, options);
+
+        if (!bundle) {
+            console.log('No match available');
+            return;
+        }
+
+        console.log('Match assembled!');
+
+        // Step 3: Submit the transaction on-chain
+        const txHash = await submitTransaction(bundle.match_bundle.settlement_tx);
+        console.log(
+            'Transaction submitted:',
+            `${walletClient.chain.blockExplorers?.default.url}/tx/${txHash}`
+        );
+    } catch (error) {
+        console.error('Error:', error);
+    }
+}
+
+// Only run if this file is being executed directly
+if (require.main === module) {
+    main().catch(console.error);
+} 

--- a/src/client.ts
+++ b/src/client.ts
@@ -106,6 +106,7 @@ export class RequestQuoteOptions {
  */
 export class AssembleExternalMatchOptions {
     doGasEstimation: boolean = false;
+    allowShared: boolean = false;
     receiverAddress?: string;
     updatedOrder?: ExternalOrder;
     requestGasSponsorship: boolean = false;
@@ -123,6 +124,14 @@ export class AssembleExternalMatchOptions {
      */
     withGasEstimation(doGasEstimation: boolean): AssembleExternalMatchOptions {
         this.doGasEstimation = doGasEstimation;
+        return this;
+    }
+
+    /**
+     * Set whether to allow shared gas sponsorship.
+     */
+    withAllowShared(allowShared: boolean): AssembleExternalMatchOptions {
+        this.allowShared = allowShared;
         return this;
     }
 
@@ -326,6 +335,7 @@ export class ExternalMatchClient {
 
         const request: AssembleExternalMatchRequest = {
             do_gas_estimation: options.doGasEstimation,
+            allow_shared: options.allowShared,
             receiver_address: options.receiverAddress,
             signed_quote: signedQuote,
             updated_order: options.updatedOrder,

--- a/src/types.ts
+++ b/src/types.ts
@@ -99,6 +99,7 @@ export interface ExternalQuoteResponse {
 
 export interface AssembleExternalMatchRequest {
     do_gas_estimation?: boolean;
+    allow_shared?: boolean;
     receiver_address?: string;
     signed_quote: ApiSignedExternalQuote;
     updated_order?: ExternalOrder;


### PR DESCRIPTION
### Purpose
This PR exposes the `allow_shared` flag on the match assembly options and adds an example with its use. 

### Testing
- [x] Example runs successfully on testnet