### PR TITLE
client, http, types, exampes: add order book depth endpoint

### DIFF
--- a/examples/order_book_depth.ts
+++ b/examples/order_book_depth.ts
@@ -1,0 +1,41 @@
+/**
+ * Example of using the Renegade External Match Client to fetch order book depth.
+ * 
+ * This example demonstrates how to create a client and request order book depth for a given base token mint.
+ */
+
+import { ExternalMatchClient } from '../index';
+import type { OrderBookDepth } from '../src/types';
+
+// Get API credentials from environment variables
+const API_KEY = process.env.EXTERNAL_MATCH_KEY || '';
+const API_SECRET = process.env.EXTERNAL_MATCH_SECRET || '';
+
+// Validate API credentials
+if (!API_KEY || !API_SECRET) {
+    console.error('Error: Missing API credentials');
+    console.error('Please set EXTERNAL_MATCH_KEY and EXTERNAL_MATCH_SECRET environment variables');
+    process.exit(1);
+}
+
+// Create the external match client
+console.log('API KEY', API_KEY);
+const client = ExternalMatchClient.newSepoliaClient(API_KEY, API_SECRET);
+
+// Example base token mint (USDC)
+const WETH = '0xc3414a7ef14aaaa9c4522dfc00a4e66e74e9c25a';
+
+async function main() {
+    try {
+        console.log('Fetching order book depth for', WETH);
+        const depth = await client.getOrderBookDepth(WETH) as OrderBookDepth;
+        console.log('Order book depth:', JSON.stringify(depth, null, 2));
+    } catch (error) {
+        console.error('Error:', error);
+    }
+}
+
+// Only run if this file is being executed directly
+if (require.main === module) {
+    main().catch(console.error);
+} 

--- a/src/client.ts
+++ b/src/client.ts
@@ -15,7 +15,8 @@ import type {
     AssembleExternalMatchRequest,
     ExternalMatchResponse,
     ApiSignedExternalQuote,
-    AtomicMatchApiBundle
+    AtomicMatchApiBundle,
+    OrderBookDepth
 } from './types';
 
 // Constants for API URLs
@@ -29,6 +30,7 @@ const RENEGADE_SDK_VERSION_HEADER = "x-renegade-sdk-version";
 // API Routes
 const REQUEST_EXTERNAL_QUOTE_ROUTE = "/v0/matching-engine/quote";
 const ASSEMBLE_EXTERNAL_MATCH_ROUTE = "/v0/matching-engine/assemble-external-match";
+const ORDER_BOOK_DEPTH_ROUTE = "/v0/order_book/depth";
 
 // Query Parameters
 const DISABLE_GAS_SPONSORSHIP_QUERY_PARAM = "disable_gas_sponsorship";
@@ -361,6 +363,34 @@ export class ExternalMatchClient {
 
             throw new ExternalMatchClientError(
                 error.message || 'Failed to assemble quote',
+                error.status
+            );
+        }
+    }
+
+    /**
+     * Get order book depth for a given base token mint.
+     * 
+     * @param mint The base token mint address
+     * @returns A promise that resolves to the order book depth
+     * @throws ExternalMatchClientError if the request fails
+     */
+    async getOrderBookDepth(mint: string): Promise<OrderBookDepth> {
+        const path = `${ORDER_BOOK_DEPTH_ROUTE}/${mint}`;
+        const headers = this.getHeaders();
+
+        try {
+            const response = await this.httpClient.get<OrderBookDepth>(path, headers);
+            if (response.status !== 200 || !response.data) {
+                throw new ExternalMatchClientError(
+                    'Failed to get order book depth',
+                    response.status
+                );
+            }
+            return response.data;
+        } catch (error: any) {
+            throw new ExternalMatchClientError(
+                error.message || 'Failed to get order book depth',
                 error.status
             );
         }

--- a/src/http.ts
+++ b/src/http.ts
@@ -27,7 +27,12 @@ const jsonProcessor = JSONBigInt({
  */
 export const parseBigJSON = (data: string) => {
     try {
-        return jsonProcessor.parse(data);
+        return JSON.parse(data, (key, value) => {
+            if (typeof value === 'string' && /^-?\d+$/.test(value)) {
+                return BigInt(value);
+            }
+            return value;
+        });
     } catch (error) {
         // If parsing fails, return original data
         console.error('Failed to parse JSON with BigInt', error);

--- a/src/types.ts
+++ b/src/types.ts
@@ -109,4 +109,16 @@ export interface ExternalMatchResponse {
     match_bundle: AtomicMatchApiBundle;
     gas_sponsored: boolean;
     gas_sponsorship_info?: GasSponsorshipInfo;
+}
+
+export interface DepthSideInfo {
+    total_quantity: bigint;
+    total_quantity_usd: number;
+}
+
+export interface OrderBookDepth {
+    price: number;
+    timestamp: number;
+    buy: DepthSideInfo;
+    sell: DepthSideInfo;
 } 


### PR DESCRIPTION
### Purpose
This PR adds methods to fetch the order book depth for a given mint. A reviver was used instead of JSONBigInt because the floating point prices were causing JSONBigInt to throw.

### Testing
- [ ] Tested locally