### PR TITLE
client: migrate to chain-aware URLs

### DIFF
--- a/examples/basic.ts
+++ b/examples/basic.ts
@@ -42,7 +42,7 @@ const walletClient = createWalletClient({
 
 // Create the external match client
 console.log("API KEY", API_KEY);
-const client = ExternalMatchClient.newSepoliaClient(API_KEY, API_SECRET);
+const client = ExternalMatchClient.newArbitrumSepoliaClient(API_KEY, API_SECRET);
 
 // Example order for USDC/WETH pair
 const order: ExternalOrder = {

--- a/examples/malleable_external_match.ts
+++ b/examples/malleable_external_match.ts
@@ -44,7 +44,7 @@ const walletClient = createWalletClient({
 
 // Create the external match client
 console.log("API KEY", API_KEY);
-const client = ExternalMatchClient.newSepoliaClient(API_KEY, API_SECRET);
+const client = ExternalMatchClient.newArbitrumSepoliaClient(API_KEY, API_SECRET);
 
 // Example order for USDC/WETH pair
 const order: ExternalOrder = {

--- a/examples/order_book_depth.ts
+++ b/examples/order_book_depth.ts
@@ -20,7 +20,7 @@ if (!API_KEY || !API_SECRET) {
 
 // Create the external match client
 console.log("API KEY", API_KEY);
-const client = ExternalMatchClient.newSepoliaClient(API_KEY, API_SECRET);
+const client = ExternalMatchClient.newArbitrumSepoliaClient(API_KEY, API_SECRET);
 
 // Example base token mint (USDC)
 const WETH = "0xc3414a7ef14aaaa9c4522dfc00a4e66e74e9c25a";

--- a/examples/shared_bundle.ts
+++ b/examples/shared_bundle.ts
@@ -42,7 +42,7 @@ const walletClient = createWalletClient({
 
 // Create the external match client
 console.log("API KEY", API_KEY);
-const client = ExternalMatchClient.newSepoliaClient(API_KEY, API_SECRET);
+const client = ExternalMatchClient.newArbitrumSepoliaClient(API_KEY, API_SECRET);
 
 // Example order for USDC/WETH pair
 const order: ExternalOrder = {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@renegade-fi/renegade-sdk",
-  "version": "0.1.3",
+  "version": "0.1.4",
   "description": "A TypeScript client for interacting with the Renegade Darkpool API",
   "module": "index.ts",
   "type": "module",

--- a/src/client.ts
+++ b/src/client.ts
@@ -7,21 +7,21 @@
 
 import { RelayerHttpClient } from "./http";
 import {
-    MalleableExternalMatchResponse,
     type ApiSignedExternalQuote,
     type AssembleExternalMatchRequest,
     type ExternalMatchResponse,
     type ExternalOrder,
     type ExternalQuoteRequest,
     type ExternalQuoteResponse,
+    MalleableExternalMatchResponse,
     type OrderBookDepth,
     type SignedExternalQuote,
 } from "./types/index";
 import { VERSION } from "./version";
 
 // Constants for API URLs
-const SEPOLIA_BASE_URL = "https://testnet.auth-server.renegade.fi";
-const MAINNET_BASE_URL = "https://mainnet.auth-server.renegade.fi";
+const ARBITRUM_SEPOLIA_BASE_URL = "https://arbitrum-sepolia.auth-server.renegade.fi";
+const ARBITRUM_ONE_BASE_URL = "https://arbitrum-one.auth-server.renegade.fi";
 
 // Header constants
 const RENEGADE_API_KEY_HEADER = "x-renegade-api-key";
@@ -271,25 +271,43 @@ export class ExternalMatchClient {
     }
 
     /**
-     * Create a new client configured for the Sepolia testnet.
+     * Create a new client configured for the Arbitrum Sepolia testnet.
+     *
+     * @deprecated Use {@link ExternalMatchClient.newArbitrumSepoliaClient} instead
+     */
+    static newSepoliaClient(apiKey: string, apiSecret: string): ExternalMatchClient {
+        return ExternalMatchClient.newArbitrumSepoliaClient(apiKey, apiSecret);
+    }
+
+    /**
+     * Create a new client configured for the Arbitrum Sepolia testnet.
      *
      * @param apiKey The API key for authentication
      * @param apiSecret The API secret for request signing
      * @returns A new ExternalMatchClient configured for Sepolia
      */
-    static newSepoliaClient(apiKey: string, apiSecret: string): ExternalMatchClient {
-        return new ExternalMatchClient(apiKey, apiSecret, SEPOLIA_BASE_URL);
+    static newArbitrumSepoliaClient(apiKey: string, apiSecret: string): ExternalMatchClient {
+        return new ExternalMatchClient(apiKey, apiSecret, ARBITRUM_SEPOLIA_BASE_URL);
     }
 
     /**
-     * Create a new client configured for mainnet.
+     * Create a new client configured for the Arbitrum One mainnet.
+     *
+     * @deprecated Use {@link ExternalMatchClient.newArbitrumOneClient} instead
+     */
+    static newMainnetClient(apiKey: string, apiSecret: string): ExternalMatchClient {
+        return ExternalMatchClient.newArbitrumOneClient(apiKey, apiSecret);
+    }
+
+    /**
+     * Create a new client configured for the Arbitrum One mainnet.
      *
      * @param apiKey The API key for authentication
      * @param apiSecret The API secret for request signing
      * @returns A new ExternalMatchClient configured for mainnet
      */
-    static newMainnetClient(apiKey: string, apiSecret: string): ExternalMatchClient {
-        return new ExternalMatchClient(apiKey, apiSecret, MAINNET_BASE_URL);
+    static newArbitrumOneClient(apiKey: string, apiSecret: string): ExternalMatchClient {
+        return new ExternalMatchClient(apiKey, apiSecret, ARBITRUM_ONE_BASE_URL);
     }
 
     /**

--- a/src/version.ts
+++ b/src/version.ts
@@ -1,7 +1,7 @@
 /**
  * SDK version information
  * This file is automatically updated during the build process
- * Last updated: 2025-04-30T15:06:15Z
+ * Last updated: 2025-05-08T00:25:05Z
  */
 
-export const VERSION = '0.1.3';
+export const VERSION = '0.1.4';


### PR DESCRIPTION
This PR migrates the Arbitrum Sepolia / One auth server URLs to the new namespace, and renames the client instantiation methods accordingly, maintaining backwards compatibility.

This was tested by running the basic example, asserting that the auth server was hit.